### PR TITLE
Add link component and include it inside navigation component

### DIFF
--- a/design/components/link/link.twig
+++ b/design/components/link/link.twig
@@ -1,0 +1,1 @@
+<a href="{{ href }}">{{ text }}</a>

--- a/design/components/navigation/navigation.twig
+++ b/design/components/navigation/navigation.twig
@@ -1,4 +1,5 @@
 <h1>My Awesome Site</h1>
 <ul>
     <li><a href="/">Home</a></li>
+    {% include 'link/link.twig' with { href: '#', text: 'Text of the link' } only %}
 </ul>


### PR DESCRIPTION
First thing's first.
Thank you for creating this repository. It has helped me a lot :)

I have a problem with component paths when I include one component within another.

I've added a "link" component and I've put it inside the "navigation" component.

In Fractal I have no problems. But when I build in metalsmith, I do not find the path.

Thanks for your time.

Francis.